### PR TITLE
Add ts-graphviz plugin to the remark plugins

### DIFF
--- a/docs/ts-graphviz/02-core-features/index.md
+++ b/docs/ts-graphviz/02-core-features/index.md
@@ -1,7 +1,6 @@
 ---
 description: Explore core APIs for graph creation and manipulation.
 ---
-import TSGraphvizLiveEditor from '@site/src/components/TSGraphvizLiveEditor';
 
 
 # Core Features
@@ -12,15 +11,14 @@ import TSGraphvizLiveEditor from '@site/src/components/TSGraphvizLiveEditor';
 
 **Playground:**
 
- <TSGraphvizLiveEditor
-  script={`import { digraph, attribute as _ } from 'ts-graphviz';
+```ts ts-graphviz:read-only
+import { digraph, attribute as _ } from 'ts-graphviz';
 
 const G = digraph('G', (g) => {
-    g.node('A', { [_.color]: 'red' });
-    g.edge(['A', 'B'], { [_.label]: 'A to B' });
-});`}
-  readOnly
-/>
+  g.node('A', { [_.color]: 'red' });
+  g.edge(['A', 'B'], { [_.label]: 'A to B' });
+});
+```
 
 :::tip
 Hover over `digraph` or `g.node` or `[_.color]` for type hints.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,7 +4,6 @@ import type { Config } from '@docusaurus/types';
 import { themes as prismThemes } from 'prism-react-renderer';
 import tsgraphviz from './plugins/remark-plugin-tsgraphviz';
 
-
 const config: Config = {
   title: 'ts-graphviz',
   tagline:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,8 @@ import type * as Preset from '@docusaurus/preset-classic';
 import npm2yarn from '@docusaurus/remark-plugin-npm2yarn';
 import type { Config } from '@docusaurus/types';
 import { themes as prismThemes } from 'prism-react-renderer';
+import tsgraphviz from './plugins/remark-plugin-tsgraphviz';
+
 
 const config: Config = {
   title: 'ts-graphviz',
@@ -31,6 +33,7 @@ const config: Config = {
             'https://pr.new/github.com//ts-graphviz/ts-graphviz.github.io/edit/main/',
           remarkPlugins: [
             [npm2yarn, { sync: true, converters: ['yarn', 'pnpm'] }],
+            [tsgraphviz, {}],
           ],
         },
         blog: {
@@ -39,11 +42,13 @@ const config: Config = {
             'https://pr.new/github.com//ts-graphviz/ts-graphviz.github.io/edit/main/',
           remarkPlugins: [
             [npm2yarn, { sync: true, converters: ['yarn', 'pnpm'] }],
+            [tsgraphviz, {}],
           ],
         },
         pages: {
           remarkPlugins: [
             [npm2yarn, { sync: true, converters: ['yarn', 'pnpm'] }],
+            [tsgraphviz, {}],
           ],
         },
         theme: {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ts-graphviz/02-core-features/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ts-graphviz/02-core-features/index.md
@@ -1,7 +1,6 @@
 ---
 description: グラフ作成と操作のためのts-graphvizの主要なAPIを紹介
 ---
-import TSGraphvizLiveEditor from '@site/src/components/TSGraphvizLiveEditor';
 
 # コア機能
 
@@ -9,17 +8,14 @@ import TSGraphvizLiveEditor from '@site/src/components/TSGraphvizLiveEditor';
 
 `ts-graphviz` は TypeScript とシームレスに統合された API を提供し、強力な型定義と完全な IntelliSense サポートを備えています。これにより、開発中のエラーをより簡単に発見でき、開発者の体験が向上します。
 
-**プレイグラウンド:**
-
-<TSGraphvizLiveEditor
-  script={`import { digraph, attribute as _ } from 'ts-graphviz';
+```ts ts-graphviz:read-only
+import { digraph, attribute as _ } from 'ts-graphviz';
 
 const G = digraph('G', (g) => {
-    g.node('A', { [_.color]: 'red' });
-    g.edge(['A', 'B'], { [_.label]: 'A to B' });
-});`}
-  readOnly
-/>
+  g.node('A', { [_.color]: 'red' });
+  g.edge(['A', 'B'], { [_.label]: 'A to B' });
+});
+```
 
 :::tip
 `digraph` や `g.node`、`[_.color]` にカーソルを合わせると型のヒントが表示されます。

--- a/package.json
+++ b/package.json
@@ -47,10 +47,15 @@
     "@docusaurus/module-type-aliases": "3.6.0",
     "@docusaurus/tsconfig": "3.6.0",
     "@docusaurus/types": "3.6.0",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
+    "@types/unist": "^3.0.3",
+    "mdast-util-mdx-jsx": "^3.1.3",
     "raw-loader": "^4.0.2",
     "typescript": "~5.6.3",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0",
     "utility-types": "^3.11.0"
   },
   "browserslist": {

--- a/plugins/remark-plugin-tsgraphviz.ts
+++ b/plugins/remark-plugin-tsgraphviz.ts
@@ -2,7 +2,6 @@ import type { Code, Literal } from 'mdast';
 import type { Plugin, Transformer } from 'unified';
 import type { Node, Parent } from 'unist';
 
-
 // biome-ignore lint/complexity/noBannedTypes: Preliminary implementation for future plugin extensibility.
 type PluginOptions = {};
 

--- a/plugins/remark-plugin-tsgraphviz.ts
+++ b/plugins/remark-plugin-tsgraphviz.ts
@@ -1,10 +1,9 @@
 import type { Code, Literal } from 'mdast';
-import type { Transformer } from 'unified';
+import type { Plugin, Transformer } from 'unified';
 import type { Node, Parent } from 'unist';
 
-type Plugin<T> = any; // TODO fix this asap
 
-// biome-ignore lint/complexity/noBannedTypes: TODO
+// biome-ignore lint/complexity/noBannedTypes: Preliminary implementation for future plugin extensibility.
 type PluginOptions = {};
 
 type CodeBlockOptions = {
@@ -37,7 +36,7 @@ const transformNode = (code: Code) => {
 
 const isMdxEsmLiteral = (node: Node): node is Literal =>
   node.type === 'mdxjsEsm';
-// TODO legacy approximation, good-enough for now but not 100% accurate
+
 const isTSGraphvizLiveEditorImport = (node: Node): boolean =>
   isMdxEsmLiteral(node) &&
   node.value.includes('@site/src/components/TSGraphvizLiveEditor');
@@ -48,7 +47,7 @@ const isTSGraphvizScript = (node: Node): node is Code =>
   node.type === 'code' && (node as Code).meta?.startsWith('ts-graphviz');
 
 const getTSGraphvizOptions = (code: Code): CodeBlockOptions => {
-  const options = code.meta.split(':').slice(1);
+  const options = code.meta ? code.meta.split(':').slice(1) : [];
   return {
     readOnly: options.includes('read-only'),
   };
@@ -118,6 +117,4 @@ const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
   };
 };
 
-// To continue supporting `require('npm2yarn')` without the `.default` ㄟ(▔,▔)ㄏ
-// TODO change to export default after migrating to ESM
 export default plugin;

--- a/plugins/remark-plugin-tsgraphviz.ts
+++ b/plugins/remark-plugin-tsgraphviz.ts
@@ -5,16 +5,13 @@ import type { Node, Parent } from 'unist';
 type Plugin<T> = any; // TODO fix this asap
 
 // biome-ignore lint/complexity/noBannedTypes: TODO
-type PluginOptions = {
-};
+type PluginOptions = {};
 
 type CodeBlockOptions = {
   readOnly: boolean;
-}
+};
 
-const transformNode = (
-  code: Code,
-) => {
+const transformNode = (code: Code) => {
   const script = code.value;
   const options = getTSGraphvizOptions(code);
   return [
@@ -33,8 +30,7 @@ const transformNode = (
           value: options.readOnly ? 'true' : 'false',
         },
       ],
-      children: [
-      ],
+      children: [],
     },
   ] as any[];
 };
@@ -43,7 +39,8 @@ const isMdxEsmLiteral = (node: Node): node is Literal =>
   node.type === 'mdxjsEsm';
 // TODO legacy approximation, good-enough for now but not 100% accurate
 const isTSGraphvizLiveEditorImport = (node: Node): boolean =>
-  isMdxEsmLiteral(node) && node.value.includes('@site/src/components/TSGraphvizLiveEditor');
+  isMdxEsmLiteral(node) &&
+  node.value.includes('@site/src/components/TSGraphvizLiveEditor');
 
 const isParent = (node: Node): node is Parent =>
   Array.isArray((node as Parent).children);
@@ -54,7 +51,7 @@ const getTSGraphvizOptions = (code: Code): CodeBlockOptions => {
   const options = code.meta.split(':').slice(1);
   return {
     readOnly: options.includes('read-only'),
-  }
+  };
 };
 
 function createImportNode() {
@@ -71,7 +68,7 @@ function createImportNode() {
             specifiers: [
               {
                 type: 'ImportDefaultSpecifier',
-                local: {type: 'Identifier', name: 'TSGraphvizLiveEditor'},
+                local: { type: 'Identifier', name: 'TSGraphvizLiveEditor' },
               },
             ],
             source: {
@@ -89,7 +86,7 @@ function createImportNode() {
 
 const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
   return async (root) => {
-    const {visit} = await import('unist-util-visit');
+    const { visit } = await import('unist-util-visit');
 
     let transformed = false;
     let alreadyImported = false;

--- a/plugins/remark-plugin-tsgraphviz.ts
+++ b/plugins/remark-plugin-tsgraphviz.ts
@@ -1,0 +1,126 @@
+import type { Code, Literal } from 'mdast';
+import type { Transformer } from 'unified';
+import type { Node, Parent } from 'unist';
+
+type Plugin<T> = any; // TODO fix this asap
+
+// biome-ignore lint/complexity/noBannedTypes: TODO
+type PluginOptions = {
+};
+
+type CodeBlockOptions = {
+  readOnly: boolean;
+}
+
+const transformNode = (
+  code: Code,
+) => {
+  const script = code.value;
+  const options = getTSGraphvizOptions(code);
+  return [
+    {
+      type: 'mdxJsxFlowElement',
+      name: 'TSGraphvizLiveEditor',
+      attributes: [
+        {
+          type: 'mdxJsxAttribute',
+          name: 'script',
+          value: script,
+        },
+        {
+          type: 'mdxJsxAttribute',
+          name: 'readOnly',
+          value: options.readOnly ? 'true' : 'false',
+        },
+      ],
+      children: [
+      ],
+    },
+  ] as any[];
+};
+
+const isMdxEsmLiteral = (node: Node): node is Literal =>
+  node.type === 'mdxjsEsm';
+// TODO legacy approximation, good-enough for now but not 100% accurate
+const isTSGraphvizLiveEditorImport = (node: Node): boolean =>
+  isMdxEsmLiteral(node) && node.value.includes('@site/src/components/TSGraphvizLiveEditor');
+
+const isParent = (node: Node): node is Parent =>
+  Array.isArray((node as Parent).children);
+const isTSGraphvizScript = (node: Node): node is Code =>
+  node.type === 'code' && (node as Code).meta?.startsWith('ts-graphviz');
+
+const getTSGraphvizOptions = (code: Code): CodeBlockOptions => {
+  const options = code.meta.split(':').slice(1);
+  return {
+    readOnly: options.includes('read-only'),
+  }
+};
+
+function createImportNode() {
+  return {
+    type: 'mdxjsEsm',
+    value:
+      "import TSGraphvizLiveEditor from '@site/src/components/TSGraphvizLiveEditor'",
+    data: {
+      estree: {
+        type: 'Program',
+        body: [
+          {
+            type: 'ImportDeclaration',
+            specifiers: [
+              {
+                type: 'ImportDefaultSpecifier',
+                local: {type: 'Identifier', name: 'TSGraphvizLiveEditor'},
+              },
+            ],
+            source: {
+              type: 'Literal',
+              value: '@site/src/components/TSGraphvizLiveEditor',
+              raw: "'@site/src/components/TSGraphvizLiveEditor'",
+            },
+          },
+        ],
+        sourceType: 'module',
+      },
+    },
+  };
+}
+
+const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
+  return async (root) => {
+    const {visit} = await import('unist-util-visit');
+
+    let transformed = false;
+    let alreadyImported = false;
+
+    visit(root, (node: Node) => {
+      if (isTSGraphvizLiveEditorImport(node)) {
+        alreadyImported = true;
+      }
+
+      if (isParent(node)) {
+        let index = 0;
+        while (index < node.children.length) {
+          const child = node.children[index]!;
+          if (isTSGraphvizScript(child)) {
+            const result = transformNode(child);
+            node.children.splice(index, 1, ...result);
+            index += result.length;
+            transformed = true;
+          } else {
+            index += 1;
+          }
+        }
+      }
+    });
+
+    if (transformed && !alreadyImported) {
+      (root as Parent).children.unshift(createImportNode());
+    }
+  };
+};
+
+// To continue supporting `require('npm2yarn')` without the `.default` ㄟ(▔,▔)ㄏ
+// TODO change to export default after migrating to ESM
+export default plugin;

--- a/plugins/remark-plugin-tsgraphviz.ts
+++ b/plugins/remark-plugin-tsgraphviz.ts
@@ -1,4 +1,5 @@
 import type { Code, Literal } from 'mdast';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import type { Plugin, Transformer } from 'unified';
 import type { Node, Parent } from 'unist';
 
@@ -9,7 +10,7 @@ type CodeBlockOptions = {
   readOnly: boolean;
 };
 
-const transformNode = (code: Code) => {
+const transformNode = (code: Code): MdxJsxFlowElement[] => {
   const script = code.value;
   const options = getTSGraphvizOptions(code);
   return [
@@ -30,7 +31,7 @@ const transformNode = (code: Code) => {
       ],
       children: [],
     },
-  ] as any[];
+  ];
 };
 
 const isMdxEsmLiteral = (node: Node): node is Literal =>
@@ -95,18 +96,16 @@ const plugin: Plugin<[PluginOptions?]> = (options = {}): Transformer => {
       }
 
       if (isParent(node)) {
-        let index = 0;
-        while (index < node.children.length) {
-          const child = node.children[index]!;
+        const newChildren: Node[] = [];
+        for (const child of node.children) {
           if (isTSGraphvizScript(child)) {
-            const result = transformNode(child);
-            node.children.splice(index, 1, ...result);
-            index += result.length;
+            newChildren.push(...transformNode(child));
             transformed = true;
           } else {
-            index += 1;
+            newChildren.push(child);
           }
         }
+        node.children = newChildren;
       }
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,18 +81,33 @@ importers:
       '@docusaurus/types':
         specifier: 3.6.0
         version: 3.6.0(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.12
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
+      mdast-util-mdx-jsx:
+        specifier: ^3.1.3
+        version: 3.1.3
       raw-loader:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.95.0)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       utility-types:
         specifier: ^3.11.0
         version: 3.11.0


### PR DESCRIPTION
This pull request includes significant updates to the documentation and introduces a new plugin for handling `ts-graphviz` code blocks in markdown files. The changes improve the way code examples are displayed and enhance the documentation configuration.

### Documentation Updates:
* Renamed `docs/ts-graphviz/02-core-features/index.mdx` to `docs/ts-graphviz/02-core-features/index.md` and updated the code block for better readability. 
* Renamed `i18n/ja/docusaurus-plugin-content-docs/current/ts-graphviz/02-core-features/index.mdx` to `i18n/ja/docusaurus-plugin-content-docs/current/ts-graphviz/02-core-features/index.md` and similarly updated the code block. 

### Configuration Changes:
* Updated `docusaurus.config.ts` to include the new `tsgraphviz` remark plugin for processing `ts-graphviz` code blocks. 

### Plugin Introduction:
* Added a new plugin `remark-plugin-tsgraphviz.ts` to transform `ts-graphviz` code blocks into `TSGraphvizLiveEditor` components, making the code examples interactive and read-only. I have added the ts-graphviz plugin to the remark plugins in order to enable the rendering of graph visualizations in the documentation. This will enhance the user experience and provide better understanding of the code examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for the `ts-graphviz` library with improved code block formatting for TypeScript examples.
	- Added a new plugin for better handling of Graphviz-related Markdown content.

- **Bug Fixes**
	- Removed the deprecated `TSGraphvizLiveEditor` component to streamline examples.

- **Documentation**
	- Updated both English and Japanese documentation to reflect changes in code presentation and usability, ensuring clarity and usability for users. 
	- Retained explanations emphasizing TypeScript's strong typing and IntelliSense support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->